### PR TITLE
Show phisher/member check UI when connected to any chain

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -45,22 +45,9 @@ function App() {
         messageLogs.push(
           "Signed delegation:",
           JSON.stringify(signedDelegation, null, 2),
-          "Signed intention to revoke:"
+          "Signed intention to revoke:",
+          JSON.stringify(signedIntendedRevocation, null, 2),
         );
-
-        const stringifiedSignedIntendedRevocation = JSON.stringify(
-          signedIntendedRevocation,
-          (key, value) => {
-            if (key === 'delegationHash' && value.type === 'Buffer') {
-              // Show hex value for delegationHash instead of Buffer
-              return ethers.utils.hexlify(Buffer.from(value));
-            }
-
-            return value;
-          },
-          2
-        )
-        messageLogs.push(stringifiedSignedIntendedRevocation);
 
         break;
       }

--- a/src/App.js
+++ b/src/App.js
@@ -38,16 +38,16 @@ function App() {
 
         break;
       }
-    
+
       case MESSAGE_KINDS.REVOKE: {
         const { signedDelegation, signedIntendedRevocation } = message;
-        
+
         messageLogs.push(
           "Signed delegation:",
           JSON.stringify(signedDelegation, null, 2),
           "Signed intention to revoke:"
         );
-      
+
         const stringifiedSignedIntendedRevocation = JSON.stringify(
           signedIntendedRevocation,
           (key, value) => {

--- a/src/MemberReport.jsx
+++ b/src/MemberReport.jsx
@@ -79,7 +79,7 @@ export default function (props) {
 function SubmitBatchButton(props) {
   const { provider, members, invitation, setMembers, p2p = false } = props;
   const peer = useContext(PeerContext);
-  
+
   const reportMembersOptions = {
     members,
     invitation

--- a/src/Members.jsx
+++ b/src/Members.jsx
@@ -120,13 +120,7 @@ export default function Members() {
       <div className="controlBoard">
         <div className="phisherBox">
           <div className="box">
-            <LazyConnect
-              actionName="check if a user is a phisher"
-              chainId={chainId}
-              opts={{ needsAccountConnected: false }}
-            >
-              <PhisherCheckButton />
-            </LazyConnect>
+            <PhisherCheckButton />
           </div>
 
           <div className="box">
@@ -136,13 +130,7 @@ export default function Members() {
 
         <div className="memberBox">
           <div className="box">
-            <LazyConnect
-              actionName="check if a user is endorsed"
-              chainId={chainId}
-              opts={{ needsAccountConnected: false }}
-            >
-              <MemberCheckButton />
-            </LazyConnect>
+            <MemberCheckButton />
           </div>
 
           <div className="box">

--- a/src/PhishingReport.jsx
+++ b/src/PhishingReport.jsx
@@ -76,7 +76,7 @@ export default function (props) {
 function SubmitBatchButton(props) {
   const { provider, phishers, invitation, setPhishers, p2p = false } = props;
   const peer = useContext(PeerContext);
-  
+
   const reportPhishersOptions = {
     phishers,
     invitation

--- a/src/ReviewAndRevokeInvitations.jsx
+++ b/src/ReviewAndRevokeInvitations.jsx
@@ -20,15 +20,15 @@ export default function (props) {
   const { provider, invitations, invitation, setInvitations, setRevokedP2PInvitations, revokedP2PInvitations = [], p2p = false } = props;
   const [registry, setRegistry] = useState(null);
   const peer = useContext(PeerContext);
-  
+
   // Get registry
   useEffect(() => {
     if (registry || !provider) {
       return;
     }
-    
+
     const ethersProvider = new ethers.providers.Web3Provider(provider, "any");
-  
+
     createRegistry(ethersProvider)
       .then(_registry => {
         setRegistry(_registry);
@@ -68,7 +68,7 @@ export default function (props) {
                   delegationHash,
                 };
                 const signedIntendedRevocation = util.signRevocation(intendedRevocation, invitation.key);
-                
+
                 if (p2p && peer) {
                   // Broadcast revocation on the network
                   await peer.floodMessage(

--- a/src/ReviewAndRevokeInvitations.jsx
+++ b/src/ReviewAndRevokeInvitations.jsx
@@ -70,6 +70,9 @@ export default function (props) {
                 const signedIntendedRevocation = util.signRevocation(intendedRevocation, invitation.key);
 
                 if (p2p && peer) {
+                  // Convert delegationHash from buffer to hex string before broadcasting as JSON on p2p network
+                  signedIntendedRevocation.intentionToRevoke.delegationHash = ethers.utils.hexlify(signedIntendedRevocation.intentionToRevoke.delegationHash)
+
                   // Broadcast revocation on the network
                   await peer.floodMessage(
                     MOBYMASK_TOPIC,

--- a/src/reportMembers.js
+++ b/src/reportMembers.js
@@ -13,7 +13,7 @@ export default async function reportMembers({ members, invitation, provider = nu
   });
 
   let registry = new ethers.Contract(address, abi);
-  
+
   if (provider) {
     const wallet = provider.getSigner();
     registry = await attachRegistry(registry, wallet);

--- a/src/reportPhishers.js
+++ b/src/reportPhishers.js
@@ -14,7 +14,7 @@ export default async function reportPhishers({ phishers, invitation, provider = 
   });
 
   let registry = new ethers.Contract(address, abi);
-  
+
   if (provider) {
     const wallet = provider.getSigner();
     registry = await attachRegistry(registry, wallet);
@@ -58,7 +58,7 @@ export default async function reportPhishers({ phishers, invitation, provider = 
       }
     );
   }
-  
+
   return registry.invoke([signedInvocations]);
 }
 


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/321

- Remove metamask wallet validation in members page for phisher/member check
  - Issue: Metamask needs to be connected to configured chain in app to check a phisher/member
  - Fix: The check for metamask connection to configured chain can be removed as phisher/member check is done using watcher GQL API
- Convert delegationHash to hex string before broadcasting as JSON over p2p network