### PR TITLE
Fixes in debug panel UI

### DIFF
--- a/src/DebugPanel.jsx
+++ b/src/DebugPanel.jsx
@@ -8,7 +8,6 @@ import Popper from '@mui/material/Popper';
 import Tab from '@mui/material/Tab';
 import TabContext from '@mui/lab/TabContext';
 import TabList from '@mui/lab/TabList';
-import TabPanel from '@mui/lab/TabPanel';
 import BugReportIcon from '@mui/icons-material/BugReport';
 import CloseIcon from '@mui/icons-material/Close';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
@@ -16,6 +15,7 @@ import { Metrics, SelfInfo, Connections, PeersGraph, NetworkGraph } from "@cerc-
 
 import config from './config.json';
 import { SubscribedMessages } from "./components/SubscribedMessages";
+import { TabPanel } from './components/TabPanel';
 
 const RESIZE_THROTTLE_TIME = 500; // ms
 const TAB_HEADER_HEIGHT = 40;
@@ -55,7 +55,7 @@ const STYLES = {
     minHeight: 32
   },
   tabPanel: {
-    padding: 0
+    paddingTop: 1/2
   },
   selfInfo: {
     marginBottom: 1

--- a/src/components/TabPanel.jsx
+++ b/src/components/TabPanel.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+import { useTabContext } from '@mui/lab/TabContext';
+import { Box } from '@mui/material';
+
+// Custom TabPanel component to keep mounted after switching to other tab
+export function TabPanel({
+  children,
+  value: id,
+  ...props
+}) {
+  const context = useTabContext()
+  const [visited, setVisited] = useState(false)
+
+  if (context === null) {
+    throw new TypeError("No TabContext provided")
+  }
+  const tabId = context.value
+
+  useEffect(() => {
+    if(id === tabId) {
+      setVisited(true)
+    }
+  }, [id, tabId]);
+
+  return (
+    <Box
+      hidden={id !== tabId}
+      {...props}
+    >
+      {visited && children}
+    </Box>
+  )
+}


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/294

- Set graph component container height according to window height
- Avoid re-rendering on switching tabs in debug panel