### PR TITLE
Upgrade cerc-io dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@apollo/client": "^3.7.2",
         "@babel/core": "^7.16.0",
-        "@cerc-io/peer": "0.2.31",
-        "@cerc-io/react-peer": "0.2.29",
+        "@cerc-io/peer": "0.2.34",
+        "@cerc-io/react-peer": "0.2.30",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@metamask/eth-sig-util": "^5.0.2",
@@ -2029,9 +2029,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@cerc-io/libp2p": {
-      "version": "0.42.2-laconic-0.1.2",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Flibp2p/-/0.42.2-laconic-0.1.2/libp2p-0.42.2-laconic-0.1.2.tgz",
-      "integrity": "sha512-FKiA5KmyWZ0gjYhbRA4bpk/V5prXJazehPLnCDjnHmHvkAe84GkmX+AZvKhTSHunkZCRy2JWclBfFocQhfLE1g==",
+      "version": "0.42.2-laconic-0.1.3",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Flibp2p/-/0.42.2-laconic-0.1.3/libp2p-0.42.2-laconic-0.1.3.tgz",
+      "integrity": "sha512-D8nBtFVB2xUN/QRCSHQVSoJBAk2nH4caqROpWUipRxiDgeoBVpTqYEM9fBzOln6/Yl3BtBxR/fgyaZPTSJQdrg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@achingbrain/nat-port-mapper": "^1.0.3",
@@ -2042,6 +2042,7 @@
         "@libp2p/interface-connection-manager": "^1.1.1",
         "@libp2p/interface-content-routing": "^2.0.0",
         "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-keychain": "^2.0.4",
         "@libp2p/interface-libp2p": "^1.0.0",
         "@libp2p/interface-metrics": "^4.0.0",
         "@libp2p/interface-peer-discovery": "^1.0.1",
@@ -2054,6 +2055,7 @@
         "@libp2p/interface-stream-muxer": "^3.0.0",
         "@libp2p/interface-transport": "^2.1.0",
         "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/keychain": "^1.0.0",
         "@libp2p/logger": "^2.0.1",
         "@libp2p/multistream-select": "^3.0.0",
         "@libp2p/peer-collections": "^3.0.0",
@@ -2070,14 +2072,11 @@
         "any-signal": "^3.0.0",
         "datastore-core": "^8.0.1",
         "err-code": "^3.0.1",
-        "events": "^3.3.0",
-        "hashlru": "^2.3.0",
         "interface-datastore": "^7.0.0",
         "it-all": "^2.0.0",
         "it-drain": "^2.0.0",
         "it-filter": "^2.0.0",
         "it-first": "^2.0.0",
-        "it-foreach": "^1.0.0",
         "it-handshake": "^4.1.2",
         "it-length-prefixed": "^8.0.2",
         "it-map": "^2.0.0",
@@ -2085,19 +2084,16 @@
         "it-pair": "^2.0.2",
         "it-pipe": "^2.0.3",
         "it-pushable": "^3.1.2",
-        "it-sort": "^2.0.0",
+        "it-sort": "^2.0.1",
         "it-stream-types": "^1.0.4",
         "merge-options": "^3.0.4",
         "multiformats": "^11.0.0",
-        "node-forge": "^1.3.1",
         "p-fifo": "^1.0.0",
-        "p-retry": "^5.0.0",
         "p-settle": "^5.0.0",
         "private-ip": "^3.0.0",
         "protons-runtime": "^4.0.1",
         "rate-limiter-flexible": "^2.3.11",
         "retimer": "^3.0.0",
-        "sanitize-filename": "^1.6.3",
         "set-delayed-interval": "^1.0.0",
         "timeout-abort-controller": "^3.0.0",
         "uint8arraylist": "^2.3.2",
@@ -2106,33 +2102,13 @@
         "xsalsa20": "^1.1.0"
       }
     },
-    "node_modules/@cerc-io/libp2p/node_modules/@types/retry": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
-    },
-    "node_modules/@cerc-io/libp2p/node_modules/p-retry": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
-      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
-      "dependencies": {
-        "@types/retry": "0.12.1",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@cerc-io/peer": {
-      "version": "0.2.31",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fpeer/-/0.2.31/peer-0.2.31.tgz",
-      "integrity": "sha512-K2/nD8t7YXPZw/uZqn1qKO6cy4701DT90p/iA2YxC9f8c/c/qSbQ6693JBFPdtGeXWmJ6mWW0Co3yjHVWNvhkQ==",
-      "license": "AGPL-version-3.0",
+      "version": "0.2.34",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fpeer/-/0.2.34/peer-0.2.34.tgz",
+      "integrity": "sha512-JZZovB2MTihBoyOQwINXP1nETJI6aKzh/aF9sQ6TKVkr/Wo7SABQMWbA/P0CBaz0GmP50k5dU7fm87Npyoe5VQ==",
+      "license": "AGPL-3.0",
       "dependencies": {
-        "@cerc-io/libp2p": "0.42.2-laconic-0.1.2",
+        "@cerc-io/libp2p": "0.42.2-laconic-0.1.3",
         "@cerc-io/prometheus-metrics": "1.1.4",
         "@chainsafe/libp2p-noise": "^11.0.0",
         "@libp2p/floodsub": "^6.0.0",
@@ -2218,12 +2194,12 @@
       }
     },
     "node_modules/@cerc-io/react-peer": {
-      "version": "0.2.29",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-peer/-/0.2.29/react-peer-0.2.29.tgz",
-      "integrity": "sha512-Mv7jLHfkdjbqYgVGBNG5to0jz4KOUzRTALabwJTEKKgkCGvhBWPbFMEL8oQgNfvimrVuyY9XvcFaeRjdI2H+sA==",
+      "version": "0.2.30",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-peer/-/0.2.30/react-peer-0.2.30.tgz",
+      "integrity": "sha512-1/dVWack5ifoPALzlcm9XX+/KurEzHc8t4OLjD51FHaHJiFPo5ya4hKJXT/4lSIpv2vopdKLuVDQB1weLLwXLg==",
       "license": "AGPL-version-3.0",
       "dependencies": {
-        "@cerc-io/peer": "^0.2.31",
+        "@cerc-io/peer": "^0.2.34",
         "@mui/lab": "^5.0.0-alpha.121",
         "@mui/material": "^5.11.3",
         "convert": "^4.10.0",
@@ -4728,6 +4704,27 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
       "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/keychain": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-1.0.1.tgz",
+      "integrity": "sha512-IvvBNcN6juPldpENiDrQFVx12573HP+jRoECGuyUBaMDy2uewFbEPWQbHFmF/kMD1IvEmAiihxrTLk7kEWllfg==",
+      "dependencies": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-keychain": "^2.0.3",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.1",
+        "interface-datastore": "^7.0.3",
+        "merge-options": "^3.0.4",
+        "sanitize-filename": "^1.6.3",
+        "uint8arrays": "^4.0.3"
+      },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -12846,11 +12843,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "node_modules/hashlru": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
-    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -17036,9 +17028,15 @@
       }
     },
     "node_modules/mortice/node_modules/nanoid": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
-      "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+      "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.js"
       },
@@ -24441,9 +24439,9 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@cerc-io/libp2p": {
-      "version": "0.42.2-laconic-0.1.2",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Flibp2p/-/0.42.2-laconic-0.1.2/libp2p-0.42.2-laconic-0.1.2.tgz",
-      "integrity": "sha512-FKiA5KmyWZ0gjYhbRA4bpk/V5prXJazehPLnCDjnHmHvkAe84GkmX+AZvKhTSHunkZCRy2JWclBfFocQhfLE1g==",
+      "version": "0.42.2-laconic-0.1.3",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Flibp2p/-/0.42.2-laconic-0.1.3/libp2p-0.42.2-laconic-0.1.3.tgz",
+      "integrity": "sha512-D8nBtFVB2xUN/QRCSHQVSoJBAk2nH4caqROpWUipRxiDgeoBVpTqYEM9fBzOln6/Yl3BtBxR/fgyaZPTSJQdrg==",
       "requires": {
         "@achingbrain/nat-port-mapper": "^1.0.3",
         "@libp2p/crypto": "^1.0.4",
@@ -24453,6 +24451,7 @@
         "@libp2p/interface-connection-manager": "^1.1.1",
         "@libp2p/interface-content-routing": "^2.0.0",
         "@libp2p/interface-dht": "^2.0.0",
+        "@libp2p/interface-keychain": "^2.0.4",
         "@libp2p/interface-libp2p": "^1.0.0",
         "@libp2p/interface-metrics": "^4.0.0",
         "@libp2p/interface-peer-discovery": "^1.0.1",
@@ -24465,6 +24464,7 @@
         "@libp2p/interface-stream-muxer": "^3.0.0",
         "@libp2p/interface-transport": "^2.1.0",
         "@libp2p/interfaces": "^3.0.3",
+        "@libp2p/keychain": "^1.0.0",
         "@libp2p/logger": "^2.0.1",
         "@libp2p/multistream-select": "^3.0.0",
         "@libp2p/peer-collections": "^3.0.0",
@@ -24481,14 +24481,11 @@
         "any-signal": "^3.0.0",
         "datastore-core": "^8.0.1",
         "err-code": "^3.0.1",
-        "events": "^3.3.0",
-        "hashlru": "^2.3.0",
         "interface-datastore": "^7.0.0",
         "it-all": "^2.0.0",
         "it-drain": "^2.0.0",
         "it-filter": "^2.0.0",
         "it-first": "^2.0.0",
-        "it-foreach": "^1.0.0",
         "it-handshake": "^4.1.2",
         "it-length-prefixed": "^8.0.2",
         "it-map": "^2.0.0",
@@ -24496,49 +24493,30 @@
         "it-pair": "^2.0.2",
         "it-pipe": "^2.0.3",
         "it-pushable": "^3.1.2",
-        "it-sort": "^2.0.0",
+        "it-sort": "^2.0.1",
         "it-stream-types": "^1.0.4",
         "merge-options": "^3.0.4",
         "multiformats": "^11.0.0",
-        "node-forge": "^1.3.1",
         "p-fifo": "^1.0.0",
-        "p-retry": "^5.0.0",
         "p-settle": "^5.0.0",
         "private-ip": "^3.0.0",
         "protons-runtime": "^4.0.1",
         "rate-limiter-flexible": "^2.3.11",
         "retimer": "^3.0.0",
-        "sanitize-filename": "^1.6.3",
         "set-delayed-interval": "^1.0.0",
         "timeout-abort-controller": "^3.0.0",
         "uint8arraylist": "^2.3.2",
         "uint8arrays": "^4.0.2",
         "wherearewe": "^2.0.0",
         "xsalsa20": "^1.1.0"
-      },
-      "dependencies": {
-        "@types/retry": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-          "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
-        },
-        "p-retry": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
-          "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
-          "requires": {
-            "@types/retry": "0.12.1",
-            "retry": "^0.13.1"
-          }
-        }
       }
     },
     "@cerc-io/peer": {
-      "version": "0.2.31",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fpeer/-/0.2.31/peer-0.2.31.tgz",
-      "integrity": "sha512-K2/nD8t7YXPZw/uZqn1qKO6cy4701DT90p/iA2YxC9f8c/c/qSbQ6693JBFPdtGeXWmJ6mWW0Co3yjHVWNvhkQ==",
+      "version": "0.2.34",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Fpeer/-/0.2.34/peer-0.2.34.tgz",
+      "integrity": "sha512-JZZovB2MTihBoyOQwINXP1nETJI6aKzh/aF9sQ6TKVkr/Wo7SABQMWbA/P0CBaz0GmP50k5dU7fm87Npyoe5VQ==",
       "requires": {
-        "@cerc-io/libp2p": "0.42.2-laconic-0.1.2",
+        "@cerc-io/libp2p": "0.42.2-laconic-0.1.3",
         "@cerc-io/prometheus-metrics": "1.1.4",
         "@chainsafe/libp2p-noise": "^11.0.0",
         "@libp2p/floodsub": "^6.0.0",
@@ -24613,11 +24591,11 @@
       }
     },
     "@cerc-io/react-peer": {
-      "version": "0.2.29",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-peer/-/0.2.29/react-peer-0.2.29.tgz",
-      "integrity": "sha512-Mv7jLHfkdjbqYgVGBNG5to0jz4KOUzRTALabwJTEKKgkCGvhBWPbFMEL8oQgNfvimrVuyY9XvcFaeRjdI2H+sA==",
+      "version": "0.2.30",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-peer/-/0.2.30/react-peer-0.2.30.tgz",
+      "integrity": "sha512-1/dVWack5ifoPALzlcm9XX+/KurEzHc8t4OLjD51FHaHJiFPo5ya4hKJXT/4lSIpv2vopdKLuVDQB1weLLwXLg==",
       "requires": {
-        "@cerc-io/peer": "^0.2.31",
+        "@cerc-io/peer": "^0.2.34",
         "@mui/lab": "^5.0.0-alpha.121",
         "@mui/material": "^5.11.3",
         "convert": "^4.10.0",
@@ -26301,6 +26279,23 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
       "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg=="
+    },
+    "@libp2p/keychain": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-1.0.1.tgz",
+      "integrity": "sha512-IvvBNcN6juPldpENiDrQFVx12573HP+jRoECGuyUBaMDy2uewFbEPWQbHFmF/kMD1IvEmAiihxrTLk7kEWllfg==",
+      "requires": {
+        "@libp2p/crypto": "^1.0.11",
+        "@libp2p/interface-keychain": "^2.0.3",
+        "@libp2p/interface-peer-id": "^2.0.1",
+        "@libp2p/interfaces": "^3.3.1",
+        "@libp2p/logger": "^2.0.5",
+        "@libp2p/peer-id": "^2.0.1",
+        "interface-datastore": "^7.0.3",
+        "merge-options": "^3.0.4",
+        "sanitize-filename": "^1.6.3",
+        "uint8arrays": "^4.0.3"
+      }
     },
     "@libp2p/logger": {
       "version": "2.0.5",
@@ -32407,11 +32402,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hashlru": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -35414,9 +35404,9 @@
       },
       "dependencies": {
         "nanoid": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.1.tgz",
-          "integrity": "sha512-udKGtCCUafD3nQtJg9wBhRP3KMbPglUsgV5JVsXhvyBs/oefqb4sqMEhKBBgqZncYowu58p1prsZQBYvAj/Gww=="
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
+          "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw=="
         },
         "p-timeout": {
           "version": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "dependencies": {
     "@apollo/client": "^3.7.2",
     "@babel/core": "^7.16.0",
-    "@cerc-io/peer": "0.2.31",
-    "@cerc-io/react-peer": "0.2.29",
+    "@cerc-io/peer": "0.2.34",
+    "@cerc-io/react-peer": "0.2.30",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@metamask/eth-sig-util": "^5.0.2",


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/294

- Upgrade `@cerc-io/peer` to `0.2.34`
- Upgrade `@cerc-io/react-peer` to `0.2.30`