### PR TITLE
Set CI env to false for ignoring build warnings

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,4 +27,4 @@ jobs:
       - name: npm publish
         # prepublishOnly script run before publish
         run: |
-          npm publish
+          CI=false npm publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/mobymask-ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://mobymask.com",
   "files": [
     "build/*"


### PR DESCRIPTION
Part of https://github.com/cerc-io/stack-orchestrator/issues/264

Existing build warnings are not ignored in CI and exits with error.
Setting `CI=false` during build ignores these warnings.