### PR TITLE
Upgrade react-peer package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "@apollo/client": "^3.7.2",
         "@babel/core": "^7.16.0",
         "@cerc-io/peer": "^0.2.41",
-        "@cerc-io/react-libp2p-debug": "^0.2.37",
-        "@cerc-io/react-peer": "^0.2.37",
+        "@cerc-io/react-libp2p-debug": "^0.2.38",
+        "@cerc-io/react-peer": "^0.2.38",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@metamask/eth-sig-util": "^5.0.2",
@@ -2104,9 +2104,9 @@
       }
     },
     "node_modules/@cerc-io/libp2p-util": {
-      "version": "0.2.37",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Flibp2p-util/-/0.2.37/libp2p-util-0.2.37.tgz",
-      "integrity": "sha512-pIk2J9eP4c63h+JPpMla6QBhheN3+TRryH4rdgO7QN3iqrXUprJN//K/4dV/msA20nKZOp/I49iXtbSivZMsQg==",
+      "version": "0.2.38",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Flibp2p-util/-/0.2.38/libp2p-util-0.2.38.tgz",
+      "integrity": "sha512-zNsP6I3eE6ePrKOrDrNc+Lnu/3sSE7GvgeGKGYXzFKMsayoJNsmPSTJ8Nk2MQtWuWCp9Q8iKR2CIVlmjdTQb8w==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@multiformats/multiaddr": "^11.1.4",
@@ -2197,12 +2197,12 @@
       }
     },
     "node_modules/@cerc-io/react-libp2p-debug": {
-      "version": "0.2.37",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-libp2p-debug/-/0.2.37/react-libp2p-debug-0.2.37.tgz",
-      "integrity": "sha512-+8Cx/lPtyPki9Dru2+H6FFeKr5SqNrRswz12+ivlFQ04bHf5OozsSL2XAqPiwr/FuSat9juEj/LIXPZgp4DWzg==",
+      "version": "0.2.38",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-libp2p-debug/-/0.2.38/react-libp2p-debug-0.2.38.tgz",
+      "integrity": "sha512-Xhnva80fOQt1/iKGfvui3/qkZnR5aCJIFCeL44sgeriet0yK8DbWZIIpmK4Uw/eOEVCKFo8f0XAjXJQyH52LNA==",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@cerc-io/libp2p-util": "^0.2.37",
+        "@cerc-io/libp2p-util": "^0.2.38",
         "@mui/icons-material": "^5.11.3",
         "@mui/lab": "^5.0.0-alpha.121",
         "@mui/material": "^5.11.3",
@@ -2211,18 +2211,18 @@
         "use-resize-observer": "^9.1.0"
       },
       "peerDependencies": {
-        "react": "16.x"
+        "react": "18.x"
       }
     },
     "node_modules/@cerc-io/react-peer": {
-      "version": "0.2.37",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-peer/-/0.2.37/react-peer-0.2.37.tgz",
-      "integrity": "sha512-0XVxkG91Ba+Tb1Hbgp3KeOQKaCErqje95HIJJ9OwLH+E81Tb9+mSf88MHwONAGtwe6+5LtogOH7zfoiFM61+SQ==",
+      "version": "0.2.38",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-peer/-/0.2.38/react-peer-0.2.38.tgz",
+      "integrity": "sha512-GmVKrSkRlLXz79pZ2b+7zxqQXv4YlbZzhzT5nLJt9OsIiaKJ3UAZ34PVlgC8LqcYz5rd5HUx8rMvT2CtK8QTtg==",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@cerc-io/libp2p-util": "^0.2.37",
+        "@cerc-io/libp2p-util": "^0.2.38",
         "@cerc-io/peer": "^0.2.50",
-        "@cerc-io/react-libp2p-debug": "^0.2.37",
+        "@cerc-io/react-libp2p-debug": "^0.2.38",
         "@mui/lab": "^5.0.0-alpha.121",
         "@mui/material": "^5.11.3",
         "convert": "^4.10.0",
@@ -24533,9 +24533,9 @@
       }
     },
     "@cerc-io/libp2p-util": {
-      "version": "0.2.37",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Flibp2p-util/-/0.2.37/libp2p-util-0.2.37.tgz",
-      "integrity": "sha512-pIk2J9eP4c63h+JPpMla6QBhheN3+TRryH4rdgO7QN3iqrXUprJN//K/4dV/msA20nKZOp/I49iXtbSivZMsQg==",
+      "version": "0.2.38",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Flibp2p-util/-/0.2.38/libp2p-util-0.2.38.tgz",
+      "integrity": "sha512-zNsP6I3eE6ePrKOrDrNc+Lnu/3sSE7GvgeGKGYXzFKMsayoJNsmPSTJ8Nk2MQtWuWCp9Q8iKR2CIVlmjdTQb8w==",
       "requires": {
         "@multiformats/multiaddr": "^11.1.4",
         "assert": "^2.0.0",
@@ -24616,11 +24616,11 @@
       }
     },
     "@cerc-io/react-libp2p-debug": {
-      "version": "0.2.37",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-libp2p-debug/-/0.2.37/react-libp2p-debug-0.2.37.tgz",
-      "integrity": "sha512-+8Cx/lPtyPki9Dru2+H6FFeKr5SqNrRswz12+ivlFQ04bHf5OozsSL2XAqPiwr/FuSat9juEj/LIXPZgp4DWzg==",
+      "version": "0.2.38",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-libp2p-debug/-/0.2.38/react-libp2p-debug-0.2.38.tgz",
+      "integrity": "sha512-Xhnva80fOQt1/iKGfvui3/qkZnR5aCJIFCeL44sgeriet0yK8DbWZIIpmK4Uw/eOEVCKFo8f0XAjXJQyH52LNA==",
       "requires": {
-        "@cerc-io/libp2p-util": "^0.2.37",
+        "@cerc-io/libp2p-util": "^0.2.38",
         "@mui/icons-material": "^5.11.3",
         "@mui/lab": "^5.0.0-alpha.121",
         "@mui/material": "^5.11.3",
@@ -24630,13 +24630,13 @@
       }
     },
     "@cerc-io/react-peer": {
-      "version": "0.2.37",
-      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-peer/-/0.2.37/react-peer-0.2.37.tgz",
-      "integrity": "sha512-0XVxkG91Ba+Tb1Hbgp3KeOQKaCErqje95HIJJ9OwLH+E81Tb9+mSf88MHwONAGtwe6+5LtogOH7zfoiFM61+SQ==",
+      "version": "0.2.38",
+      "resolved": "https://git.vdb.to/api/packages/cerc-io/npm/%40cerc-io%2Freact-peer/-/0.2.38/react-peer-0.2.38.tgz",
+      "integrity": "sha512-GmVKrSkRlLXz79pZ2b+7zxqQXv4YlbZzhzT5nLJt9OsIiaKJ3UAZ34PVlgC8LqcYz5rd5HUx8rMvT2CtK8QTtg==",
       "requires": {
-        "@cerc-io/libp2p-util": "^0.2.37",
+        "@cerc-io/libp2p-util": "^0.2.38",
         "@cerc-io/peer": "^0.2.50",
-        "@cerc-io/react-libp2p-debug": "^0.2.37",
+        "@cerc-io/react-libp2p-debug": "^0.2.38",
         "@mui/lab": "^5.0.0-alpha.121",
         "@mui/material": "^5.11.3",
         "convert": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/mobymask-ui",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "homepage": "https://mobymask.com",
   "files": [
     "build/*"
@@ -9,8 +9,8 @@
     "@apollo/client": "^3.7.2",
     "@babel/core": "^7.16.0",
     "@cerc-io/peer": "^0.2.41",
-    "@cerc-io/react-libp2p-debug": "^0.2.37",
-    "@cerc-io/react-peer": "^0.2.37",
+    "@cerc-io/react-libp2p-debug": "^0.2.38",
+    "@cerc-io/react-peer": "^0.2.38",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@metamask/eth-sig-util": "^5.0.2",


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/321

Upgrade `react-peer` and `react-libp2p-debug` packages to fix peer dependency error
```
$npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @cerc-io/react-libp2p-debug@0.2.37
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"^18.2.0" from the root project
npm ERR!   peerOptional react@"^16.8.0 || ^17.0.0 || ^18.0.0" from @apollo/client@3.7.2
npm ERR!   node_modules/@apollo/client
npm ERR!     @apollo/client@"^3.7.2" from the root project
npm ERR!   20 more (@cerc-io/react-peer, @emotion/react, @emotion/styled, ...)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"16.x" from @cerc-io/react-libp2p-debug@0.2.37
npm ERR! node_modules/@cerc-io/react-libp2p-debug
npm ERR!   @cerc-io/react-libp2p-debug@"^0.2.37" from the root project
npm ERR!   @cerc-io/react-libp2p-debug@"^0.2.37" from @cerc-io/react-peer@0.2.37
npm ERR!   node_modules/@cerc-io/react-peer
npm ERR!     @cerc-io/react-peer@"^0.2.37" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: react@16.14.0
npm ERR! node_modules/react
npm ERR!   peer react@"16.x" from @cerc-io/react-libp2p-debug@0.2.37
npm ERR!   node_modules/@cerc-io/react-libp2p-debug
npm ERR!     @cerc-io/react-libp2p-debug@"^0.2.37" from the root project
npm ERR!     @cerc-io/react-libp2p-debug@"^0.2.37" from @cerc-io/react-peer@0.2.37
npm ERR!     node_modules/@cerc-io/react-peer
npm ERR!       @cerc-io/react-peer@"^0.2.37" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```